### PR TITLE
change class name from .material-icon to .material-symbols-outlined

### DIFF
--- a/assets/scss/pages/_index.scss
+++ b/assets/scss/pages/_index.scss
@@ -428,7 +428,7 @@
         min-height: 64px;
     }
 
-    .material-icons {
+    .material-symbols-outlined {
         vertical-align: sub;
     }
 


### PR DESCRIPTION
發現少改到一個小地方
google icon 的 class name 上次有更新～